### PR TITLE
Fix build issue due to typo in variable name

### DIFF
--- a/src/main/kotlin/me/adrian3d/vlobby/configuration/Configuration.kt
+++ b/src/main/kotlin/me/adrian3d/vlobby/configuration/Configuration.kt
@@ -37,7 +37,7 @@ class Configuration(toml: Toml) {
     class Messages(toml: Toml?) {
         val errorMessage: String
         val notAvailableServerMessage: String
-        val succesfullyMessage: String
+        val successfullyMessage: String
         val consoleMessage: String
 
         init {
@@ -45,13 +45,13 @@ class Configuration(toml: Toml) {
                 errorMessage = toml.getString("error", "<red>You could not be transported to the server <server>")
                 notAvailableServerMessage =
                     toml.getString("not-available-server", "<red>No lobby servers available now, try again later")
-                succesfullyMessage =
+                successfullyMessage =
                     toml.getString("succesfully", "<red>You have been successfully sent to the lobby <server>")
                 consoleMessage = toml.getString("console-message", "The console could not be teleported to the lobby")
             } else {
                 errorMessage = "<red>You could not be transported to the server <server>"
                 notAvailableServerMessage = "<red>No lobby servers available now, try again later"
-                succesfullyMessage = "<red>You have been successfully sent to the lobby <server>"
+                successfullyMessage = "<red>You have been successfully sent to the lobby <server>"
                 consoleMessage = "The console could not be teleported to the lobby"
             }
         }

--- a/src/main/kotlin/me/adrian3d/vlobby/configuration/Configuration.kt
+++ b/src/main/kotlin/me/adrian3d/vlobby/configuration/Configuration.kt
@@ -46,7 +46,7 @@ class Configuration(toml: Toml) {
                 notAvailableServerMessage =
                     toml.getString("not-available-server", "<red>No lobby servers available now, try again later")
                 successfullyMessage =
-                    toml.getString("succesfully", "<red>You have been successfully sent to the lobby <server>")
+                    toml.getString("successfully", "<red>You have been successfully sent to the lobby <server>")
                 consoleMessage = toml.getString("console-message", "The console could not be teleported to the lobby")
             } else {
                 errorMessage = "<red>You could not be transported to the server <server>"

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -11,7 +11,7 @@ servers = ["lobby1", "lobby2"]
 send-mode = "RANDOM"
 
 [messages]
-succesfully = "<red>You have been successfully sent to the lobby <server>"
+successfully = "<red>You have been successfully sent to the lobby <server>"
 error = "<red>You could not be transported to the server <server>"
 not-available-server = "<red>No lobby servers available now, try again later"
 console-message = "The console could not be teleported to the lobby"


### PR DESCRIPTION
succesfullyMessage -> successfullyMessage

I also went ahead and fixed up the other typos for 'successfully'