### PR TITLE
Update requirements to include MCKotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Lobby plugin for Velocity
 ## Requirements
 - Velocity 3.1.2|3.2.0+
 - Java 11+
+- [MCKotlin Velocity](https://modrinth.com/plugin/mckotlin)
 
 ## Features
 - Multi lobby support


### PR DESCRIPTION
Hi,

When I loaded up your plugin I saw it required the kotlin library.
I've added it to the requirements just to help other people downloading this plugin to avoid the issue.

Kind Regards,
Mac